### PR TITLE
Added S compilation and paths to linking step

### DIFF
--- a/ino/make/Makefile.jinja
+++ b/ino/make/Makefile.jinja
@@ -38,9 +38,11 @@ include {{ target.path|depsname }}
 {% for source_dir, target in libs.items() %}
 {% set c = source_dir|glob('*.c')|filemap(target.dirname, e.names.obj) %}
 {% set cpp = (source_dir|glob('*.cpp'))|filemap(target.dirname, e.names.obj) %}
-{% set libobjs = c.target_paths() + cpp.target_paths() %}
+{% set S = (source_dir|glob('*.S'))|filemap(target.dirname, e.names.obj) %}
+{% set libobjs = c.target_paths() + cpp.target_paths() + S.target_paths() %}
 {{ compile_c(c) }}
 {{ compile_cpp(cpp) }}
+{{ compile_S(S) }}
 {{ target.path }} : {{ libobjs }}
 	@echo {{ ('Linking ' ~ target.filename|basename)|colorize('green') }}
 	{{v}}{{ e.ar }} rcs $@ $^


### PR DESCRIPTION
Hey @aczid,

Thanks for your work to add .S support to ino :)

I had to make a small change to the Makefile template to get the linking to work on one of my projects as it wasn't including the .S files in that step. I just followed the existing pattern that was there for .c and .cpp files.

Hopefully your pull request to the main project will get picked up - would you consider adding the changes I made, too?

Cheers,
Josh
